### PR TITLE
handle unicode properties

### DIFF
--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -118,9 +118,12 @@ class VectorTile:
                     if (isinstance(v,bool)):
                         val = layer.values.add()
                         val.bool_value = v
-                    elif (isinstance(v,str)) or (isinstance(v,unicode)):
+                    elif (isinstance(v,str)):
                         val = layer.values.add()
                         val.string_value = unicode(v,'utf8')
+                    elif (isinstance(v,unicode)):
+                        val = layer.values.add()
+                        val.string_value = v
                     elif (isinstance(v,int)) or (isinstance(v,long)):
                         val = layer.values.add()
                         val.int_value = v

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -73,6 +73,19 @@ class TestDifferentGeomFormats(unittest.TestCase):
             }])
         self.assertEqual(ex.exception[0], expected_result)
 
+    def test_encode_unicode_property(self):
+        geometry = "LINESTRING(-71.160281 42.258729,-71.160837 42.259113,-71.161144 42.25932)"
+        self.feature_properties["foo"] = unicode(self.feature_properties["foo"])
+        self.feature_properties["baz"] = unicode(self.feature_properties["baz"])
+        expected_result = '\x1aE\n\x05water\x12\x16\x12\x06\x00\x00\x01\x01\x02\x02\x18\x02"\n\t\x8d\x01\xaa?\x12\x00\x00\x00\x00\x1a\x03foo\x1a\x03baz\x1a\x03uid"\x05\n\x03bar"\x05\n\x03foo"\x02 {(\x80 x\x02'
+        self.assertEqual(mapbox_vector_tile.encode([{
+                "name": self.layer_name,
+                "features": [{
+                    "geometry": geometry,
+                    "properties": self.feature_properties
+                }]
+            }]), expected_result)
+
     def test_encode_float_little_endian(self):
         geometry = "LINESTRING(-71.160281 42.258729,-71.160837 42.259113,-71.161144 42.25932)"
         expected_result = '\x1a\\\n\x05water\x12\x18\x12\x08\x00\x00\x01\x01\x02\x02\x03\x03\x18\x02"\n\t\x8d\x01\xaa?\x12\x00\x00\x00\x00\x1a\x08floatval\x1a\x03foo\x1a\x03baz\x1a\x03uid"\t\x19n\x86\x1b\xf0\xf9!\t@"\x05\n\x03bar"\x05\n\x03foo"\x02 {(\x80 x\x02'


### PR DESCRIPTION
If you try to encode a string feature that's already unicode, the current code crashes.  This handles it.  