### PR TITLE
Allow encoder to accept shapely objects directly

### DIFF
--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -2,6 +2,7 @@ import types
 from Mapbox import vector_tile_pb2
 from shapely.wkb import loads as load_wkb
 from shapely.wkt import loads as load_wkt
+from shapely.geometry.base import BaseGeometry
 from numbers import Number
 
 from math import floor, fabs
@@ -68,6 +69,9 @@ class VectorTile:
         return exploded_features
 
     def _load_geometry(self, wkb_or_wkt):
+        if isinstance(wkb_or_wkt, BaseGeometry):
+            return wkb_or_wkt
+
         try:
             return load_wkb(wkb_or_wkt)
         except:


### PR DESCRIPTION
This came up when optimizing my tile generation code. When sending wkt to `.encode()`, there was significant time being spent in `wkb.loads` just to find out that the argument was not wkb. Furthermore, because I'm working with the objects before sending to `.encode`, this change allows me to skip the object -> wkt/wkb -> object transformation and just pass in an object directly.

Thanks!