### PR TITLE
Enforce proper winding order on multipolygons

### DIFF
--- a/mapbox_vector_tile/decoder.py
+++ b/mapbox_vector_tile/decoder.py
@@ -97,10 +97,15 @@ class TileData:
 
             elif cmd == CMD_MOVE_TO or cmd == CMD_LINE_TO:
 
-                if ftype == LINESTRING and coords and cmd == CMD_MOVE_TO:
-                    # multi line string
-                    parts.append(coords)
-                    coords = []
+                if coords and cmd == CMD_MOVE_TO:
+                    if ftype in (LINESTRING, POLYGON):
+                        # multi line string or polygon
+                        # our encoder includes CMD_SEG_END to denote
+                        # the end of a polygon ring, but this path
+                        # would also handle the case where we receive
+                        # a move without a previous close on polygons
+                        parts.append(coords)
+                        coords = []
 
                 for point in xrange(0, cmd_len):
                     x = geom[i]

--- a/mapbox_vector_tile/decoder.py
+++ b/mapbox_vector_tile/decoder.py
@@ -89,9 +89,13 @@ class TileData:
 
             i = i + 1
 
-            if cmd == CMD_SEG_END:
-                if ftype == POLYGON and coords:
+            def _ensure_polygon_closed(coords):
+                if coords and coords[0] != coords[-1]:
                     coords.append(coords[0])
+
+            if cmd == CMD_SEG_END:
+                if ftype == POLYGON:
+                    _ensure_polygon_closed(coords)
                 parts.append(coords)
                 coords = []
 
@@ -104,6 +108,11 @@ class TileData:
                         # the end of a polygon ring, but this path
                         # would also handle the case where we receive
                         # a move without a previous close on polygons
+
+                        # for polygons, we want to ensure that it is
+                        # closed
+                        if ftype == POLYGON:
+                            _ensure_polygon_closed(coords)
                         parts.append(coords)
                         coords = []
 
@@ -128,7 +137,7 @@ class TileData:
 
         if ftype == POINT:
             return coords
-        elif ftype == LINESTRING or ftype == POLYGON:
+        elif ftype in (LINESTRING, POLYGON):
             if parts:
                 if coords:
                     parts.append(coords)

--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -67,6 +67,11 @@ class VectorTile:
                 # and the beginning of another are signaled.
                 shape = self.enforce_multipolygon_winding_order(shape)
 
+            elif shape.type == 'Polygon':
+                # Ensure that polygons are also oriented with the
+                # appropriate winding order
+                shape = orient(shape, sign=1.0)
+
             self.addFeature(feature, shape)
 
     def enforce_multipolygon_winding_order(self, shape):

--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -1,6 +1,8 @@
 from math import fabs
 from numbers import Number
 from shapely.geometry.base import BaseGeometry
+from shapely.geometry.multipolygon import MultiPolygon
+from shapely.geometry.polygon import orient
 from shapely.wkb import loads as load_wkb
 from shapely.wkt import loads as load_wkt
 import sys
@@ -46,34 +48,36 @@ class VectorTile:
             if geometry_spec is None:
                 continue
             shape = self._load_geometry(geometry_spec)
+
             if shape is None:
                 raise NotImplementedError(
                     'Can\'t do geometries that are not wkt, wkb, or shapely '
                     'geometries')
+
             if shape.is_empty:
                 continue
-            # if we are a multipolygon, we will create separate
-            # features for each polygon and duplicate properties
-            if shape.type == 'MultiPolygon':
-                exploded_features = self.explode_multipolygon_features(
-                    feature, shape)
-                for exploded_feature in exploded_features:
-                    self.addFeature(exploded_feature,
-                                    exploded_feature['geometry'])
-            else:
-                self.addFeature(feature, shape)
 
-    def explode_multipolygon_features(self, feature, shape):
+            if shape.type == 'MultiPolygon':
+                # If we are a multipolygon, we need to ensure that the
+                # winding orders of the consituent polygons are
+                # correct. In particular, the winding order of the
+                # interior rings need to be the opposite of the
+                # exterior ones, and all interior rings need to follow
+                # the exterior one. This is how the end of one polygon
+                # and the beginning of another are signaled.
+                shape = self.enforce_multipolygon_winding_order(shape)
+
+            self.addFeature(feature, shape)
+
+    def enforce_multipolygon_winding_order(self, shape):
         assert shape.type == 'MultiPolygon'
-        exploded_features = []
-        properties = feature['properties']
-        feature_id = feature.get('id')
-        for geometry in shape.geoms:
-            new_feature = dict(properties=properties, geometry=geometry)
-            if feature_id is not None:
-                new_feature['id'] = feature_id
-            exploded_features.append(new_feature)
-        return exploded_features
+
+        parts = []
+        for part in shape.geoms:
+            part = orient(part, sign=1.0)
+            parts.append(part)
+        oriented_shape = MultiPolygon(parts)
+        return oriented_shape
 
     def _load_geometry(self, geometry_spec):
         if isinstance(geometry_spec, BaseGeometry):

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -29,3 +29,24 @@ class BaseTestCase(unittest.TestCase):
                 'type': 3
             }]
         })
+
+    def test_decode_polygon_no_cmd_seg_end(self):
+        # the binary here was generated without including the
+        # CMD_SEG_END after the polygon parts
+        # this tests that the decoder can detect that a new
+        # CMD_MOVE_TO implicitly closes the previous polygon
+        if PY3:
+            vector_tile = b'\x1a+\n\x05water\x12\x1d\x18\x03"\x19\t\x00\x80@"\x08\x00\x00\x07\x07\x00\x00\x08\t\x02\x01"\x00\x03\x04\x00\x00\x04\x03\x00(\x80 x\x02'  # noqa
+        else:
+            vector_tile = '\x1a+\n\x05water\x12\x1d\x18\x03"\x19\t\x00\x80@"\x08\x00\x00\x07\x07\x00\x00\x08\t\x02\x01"\x00\x03\x04\x00\x00\x04\x03\x00(\x80 x\x02'  # noqa
+        self.assertEqual(mapbox_vector_tile.decode(vector_tile), {
+            'water': [{
+                'geometry': [
+                    [[0, 0], [4, 0], [4, 4], [0, 4], [0, 0]],
+                    [[1, 1], [1, 3], [3, 3], [3, 1], [1, 1]],
+                ],
+                'properties': {},
+                'id': 0,
+                'type': 3
+            }]
+        })

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -129,8 +129,31 @@ class TestDifferentGeomFormats(BaseTestCase):
         self.assertRoundTrip(input_geometry=geometry,
                              expected_geometry=[[1, 1]], id=42)
 
-    def test_encode_multipolygon(self):
-        geometry = 'MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20)))'  # noqa
+    def test_encode_multilinestring(self):
+        geometry = 'MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))'  # noqa
         self.assertRoundTrip(input_geometry=geometry,
-                             expected_geometry=[[40, 40], [20, 45], [45, 30], [40, 40]],  # noqa
-                             expected_len=2)
+                             expected_geometry=[
+                                 [[10, 10], [20, 20], [10, 40]],
+                                 [[40, 40], [30, 30], [40, 20], [30, 10]],
+                             ])
+
+    def test_encode_multipolygon_normal_winding_order(self):
+        geometry = 'MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20)))'  # noqa
+        self.assertRoundTrip(
+            input_geometry=geometry,
+            expected_geometry=[
+                [[40, 40], [20, 45], [45, 30], [40, 40]],
+                [[20, 35], [10, 30], [10, 10], [30, 5], [45, 20], [20, 35]],
+                [[30, 20], [20, 15], [20, 25], [30, 20]],
+            ],
+            expected_len=1)
+
+    def test_encode_multipolygon_reverse_winding_order(self):
+        geometry = 'MULTIPOLYGON (((10 10, 10 0, 0 0, 0 10, 10 10), (8 8, 2 8, 2 0, 8 0, 8 8)))'  # noqa
+        self.assertRoundTrip(
+            input_geometry=geometry,
+            expected_geometry=[
+                [[10, 10], [0, 10], [0, 0], [10, 0], [10, 10]],
+                [[8, 8], [8, 0], [2, 0], [2, 8], [8, 8]],
+            ],
+            expected_len=1)

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -56,8 +56,8 @@ class TestDifferentGeomFormats(BaseTestCase):
 
     def test_encoder(self):
         self.assertRoundTrip(
-            input_geometry='POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))',
-            expected_geometry=[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]])
+            input_geometry='POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))',
+            expected_geometry=[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]])
 
     def test_with_wkt(self):
         self.assertRoundTrip(
@@ -67,7 +67,7 @@ class TestDifferentGeomFormats(BaseTestCase):
     def test_with_wkb(self):
         self.assertRoundTrip(
             input_geometry=b"\001\003\000\000\000\001\000\000\000\005\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\360?\000\000\000\000\000\000\360?\000\000\000\000\000\000\360?\000\000\000\000\000\000\360?\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000",  # noqa
-            expected_geometry=[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]])
+            expected_geometry=[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]])
 
     def test_with_shapely(self):
         geometry = "LINESTRING(-71.160281 42.258729,-71.160837 42.259113,-71.161144 42.25932)"  # noqa
@@ -128,6 +128,12 @@ class TestDifferentGeomFormats(BaseTestCase):
         geometry = 'POINT(1 1)'
         self.assertRoundTrip(input_geometry=geometry,
                              expected_geometry=[[1, 1]], id=42)
+
+    def test_encode_polygon_reverse_winding_order(self):
+        geometry = 'POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))'
+        self.assertRoundTrip(
+            input_geometry=geometry,
+            expected_geometry=[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]])
 
     def test_encode_multilinestring(self):
         geometry = 'MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))'  # noqa


### PR DESCRIPTION
Refs #20

To handle multipolygons, instead of cloning features with each part, the
winding order of the parts will signal when a new multipolygon starts.

@zerebubuth: could you review please?