### PR TITLE
Flip the orientation of polygons in MVT.

### DIFF
--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -69,8 +69,14 @@ class VectorTile:
 
             elif shape.type == 'Polygon':
                 # Ensure that polygons are also oriented with the
-                # appropriate winding order
-                shape = orient(shape, sign=1.0)
+                # appropriate winding order. Their exterior rings must
+                # have a clockwise order, which is translated into a
+                # clockwise order in MVT's tile-local coordinates with
+                # the Y axis in "screen" (i.e: +ve down) configuration.
+                # Note that while the Y axis flips, we also invert the
+                # Y coordinate to get the tile-local value, which means
+                # the clockwise orientation is unchanged.
+                shape = orient(shape, sign=-1.0)
 
             self.addFeature(feature, shape)
 
@@ -79,7 +85,9 @@ class VectorTile:
 
         parts = []
         for part in shape.geoms:
-            part = orient(part, sign=1.0)
+            # see comment in shape.type == 'Polygon' above about why
+            # the sign here has to be -1.
+            part = orient(part, sign=-1.0)
             parts.append(part)
         oriented_shape = MultiPolygon(parts)
         return oriented_shape

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -57,7 +57,7 @@ class TestDifferentGeomFormats(BaseTestCase):
     def test_encoder(self):
         self.assertRoundTrip(
             input_geometry='POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))',
-            expected_geometry=[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]])
+            expected_geometry=[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]])
 
     def test_with_wkt(self):
         self.assertRoundTrip(
@@ -67,7 +67,7 @@ class TestDifferentGeomFormats(BaseTestCase):
     def test_with_wkb(self):
         self.assertRoundTrip(
             input_geometry=b"\001\003\000\000\000\001\000\000\000\005\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\360?\000\000\000\000\000\000\360?\000\000\000\000\000\000\360?\000\000\000\000\000\000\360?\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000",  # noqa
-            expected_geometry=[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]])
+            expected_geometry=[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]])
 
     def test_with_shapely(self):
         geometry = "LINESTRING(-71.160281 42.258729,-71.160837 42.259113,-71.161144 42.25932)"  # noqa
@@ -133,7 +133,7 @@ class TestDifferentGeomFormats(BaseTestCase):
         geometry = 'POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))'
         self.assertRoundTrip(
             input_geometry=geometry,
-            expected_geometry=[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]])
+            expected_geometry=[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]])
 
     def test_encode_multilinestring(self):
         geometry = 'MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))'  # noqa
@@ -148,9 +148,9 @@ class TestDifferentGeomFormats(BaseTestCase):
         self.assertRoundTrip(
             input_geometry=geometry,
             expected_geometry=[
-                [[40, 40], [20, 45], [45, 30], [40, 40]],
-                [[20, 35], [10, 30], [10, 10], [30, 5], [45, 20], [20, 35]],
-                [[30, 20], [20, 15], [20, 25], [30, 20]],
+                [[40, 40], [45, 30], [20, 45], [40, 40]],
+                [[20, 35], [45, 20], [30,  5], [10, 10], [10, 30], [20, 35]],
+                [[30, 20], [20, 25], [20, 15], [30, 20]],
             ],
             expected_len=1)
 
@@ -159,7 +159,7 @@ class TestDifferentGeomFormats(BaseTestCase):
         self.assertRoundTrip(
             input_geometry=geometry,
             expected_geometry=[
-                [[10, 10], [0, 10], [0, 0], [10, 0], [10, 10]],
-                [[8, 8], [8, 0], [2, 0], [2, 8], [8, 8]],
+                [[10, 10], [10, 0], [0, 0], [0, 10], [10, 10]],
+                [[8, 8], [2, 8], [2, 0], [8, 0], [8, 8]],
             ],
             expected_len=1)


### PR DESCRIPTION
The [MVT docs](https://github.com/mapbox/vector-tile-spec/pull/36/files#diff-3594e5e9052be0e33421df52071394d9R31) say that:

> In a frame where the Y axis is positive up, this would make the winding order appear counter clockwise.

However, this doesn't mean that we can orient our polygons as counter-clockwise, as part of the encoding process for encoding is flipping the Y coordinate (`'y': self.extents - y`). This means that the orientation of the polygons doesn't change as part of the encoding process, and therefore exterior rings must be *clockwise* when we encode them.