### PR TITLE
Sanitise attributes before outputting them.

### DIFF
--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -144,8 +144,8 @@ class VectorTile:
             return True
         elif isinstance(v, bool):
             return True
-        elif isinstance(v, int) or \
-             isinstance(v, int if PY3 else long):
+        elif (isinstance(v, int) or
+              isinstance(v, int if PY3 else long)):
             return True
         elif isinstance(v, float):
             return True

--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -134,9 +134,31 @@ class VectorTile:
     def _chunker(self, seq, size):
         return [seq[pos:pos + size] for pos in xrange(0, len(seq), size)]
 
+    def _can_handle_key(self, k):
+        return isinstance(k, str) or \
+            isinstance(k, str if PY3 else unicode)
+
+    def _can_handle_val(self, v):
+        if isinstance(v, str) or \
+           isinstance(v, str if PY3 else unicode):
+            return True
+        elif isinstance(v, bool):
+            return True
+        elif isinstance(v, int) or \
+             isinstance(v, int if PY3 else long):
+            return True
+        elif isinstance(v, float):
+            return True
+
+        return False
+
+    def _can_handle_attr(self, k, v):
+        return self._can_handle_key(k) and \
+            self._can_handle_val(v)
+
     def _handle_attr(self, layer, feature, props):
         for k, v in props.items():
-            if v is not None:
+            if self._can_handle_attr(k, v):
                 if not PY3 and isinstance(k, str):
                     k = k.decode('utf-8')
                 if k not in self.keys:
@@ -145,24 +167,20 @@ class VectorTile:
                 feature.tags.append(self.keys.index(k))
                 if v not in self.values:
                     self.values.append(v)
+                    val = layer.values.add()
                     if isinstance(v, bool):
-                        val = layer.values.add()
                         val.bool_value = v
                     elif (isinstance(v, str)):
-                        val = layer.values.add()
                         if PY3:
                             val.string_value = str(v)
                         else:
                             val.string_value = unicode(v, 'utf8')
                     elif (isinstance(v, str if PY3 else unicode)):
-                        val = layer.values.add()
                         val.string_value = v
                     elif (isinstance(v, int)) or (
                             isinstance(v, int if PY3 else long)):
-                        val = layer.values.add()
                         val.int_value = v
                     elif (isinstance(v, float)):
-                        val = layer.values.add()
                         val.double_value = v
                 feature.tags.append(self.values.index(v))
 

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -178,7 +178,6 @@ class TestDifferentGeomFormats(BaseTestCase):
             expected_geometry=[[0, 0]],
             properties=properties)
 
-
     def test_encode_property_long(self):
         geometry = 'POINT(0 0)'
         properties = {
@@ -200,16 +199,16 @@ class TestDifferentGeomFormats(BaseTestCase):
             input_geometry=geometry,
             expected_geometry=[[0, 0]],
             properties=properties,
-            expected_properties={'test_empty':''})
+            expected_properties={'test_empty': ''})
 
     def test_encode_property_list(self):
         geometry = 'POINT(0 0)'
         properties = {
-            'test_list': [1,2,3],
+            'test_list': [1, 2, 3],
             'test_empty': ""
         }
         self.assertRoundTrip(
             input_geometry=geometry,
             expected_geometry=[[0, 0]],
             properties=properties,
-            expected_properties={'test_empty':''})
+            expected_properties={'test_empty': ''})

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -25,13 +25,16 @@ class BaseTestCase(unittest.TestCase):
         self.feature_geometry = 'POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))'
 
     def assertRoundTrip(self, input_geometry, expected_geometry, name=None,
-                        properties=None, id=None, expected_len=1):
+                        properties=None, id=None, expected_len=1,
+                        expected_properties=None):
         if input_geometry is None:
             input_geometry = self.feature_geometry
         if name is None:
             name = self.layer_name
         if properties is None:
             properties = self.feature_properties
+        if expected_properties is None:
+            expected_properties = properties
         source = [{
             "name": name,
             "features": [{
@@ -46,7 +49,7 @@ class BaseTestCase(unittest.TestCase):
         self.assertIn(name, decoded)
         features = decoded[name]
         self.assertEqual(expected_len, len(features))
-        self.assertEqual(features[0]['properties'], properties)
+        self.assertEqual(features[0]['properties'], expected_properties)
         self.assertEqual(features[0]['geometry'], expected_geometry)
         if id:
             self.assertEqual(decoded[name][0]['id'], id)
@@ -163,3 +166,50 @@ class TestDifferentGeomFormats(BaseTestCase):
                 [[8, 8], [2, 8], [2, 0], [8, 0], [8, 8]],
             ],
             expected_len=1)
+
+    def test_encode_property_bool(self):
+        geometry = 'POINT(0 0)'
+        properties = {
+            'test_bool_true': True,
+            'test_bool_false': False
+        }
+        self.assertRoundTrip(
+            input_geometry=geometry,
+            expected_geometry=[[0, 0]],
+            properties=properties)
+
+
+    def test_encode_property_long(self):
+        geometry = 'POINT(0 0)'
+        properties = {
+            'test_int': int(1),
+            'test_long': long(1)
+        }
+        self.assertRoundTrip(
+            input_geometry=geometry,
+            expected_geometry=[[0, 0]],
+            properties=properties)
+
+    def test_encode_property_null(self):
+        geometry = 'POINT(0 0)'
+        properties = {
+            'test_none': None,
+            'test_empty': ""
+        }
+        self.assertRoundTrip(
+            input_geometry=geometry,
+            expected_geometry=[[0, 0]],
+            properties=properties,
+            expected_properties={'test_empty':''})
+
+    def test_encode_property_list(self):
+        geometry = 'POINT(0 0)'
+        properties = {
+            'test_list': [1,2,3],
+            'test_empty': ""
+        }
+        self.assertRoundTrip(
+            input_geometry=geometry,
+            expected_geometry=[[0, 0]],
+            properties=properties,
+            expected_properties={'test_empty':''})


### PR DESCRIPTION
Attributes up to this point have been arbitray Python objects, and elsewhere we serialise them to JSON, but both Python and JSON have a richer selection of basic types than MVT allows.

For example, transit routes are output as a `list`, which is fine in JSON, but led to an off-by one in MVT as it was added to `self.values` but not `layer.values` since it did not match any clause of the `isinstance` testing.

Added test cases which check this and a few other cases. Fixed by filtering on the types allowed for both key and value before attempting to add either.

Fixes  mapzen/tilequeue#53.

@rmarianski could you review, please?