### PR TITLE
Improve values lookup

### DIFF
--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -40,6 +40,7 @@ class VectorTile:
         self.layer.extent = self.extents
         self.keys = []
         self.values = []
+        self.seen_values = set()
 
         for feature in features:
 
@@ -165,8 +166,9 @@ class VectorTile:
                     layer.keys.append(k)
                     self.keys.append(k)
                 feature.tags.append(self.keys.index(k))
-                if v not in self.values:
+                if v not in self.seen_values:
                     self.values.append(v)
+                    self.seen_values.add(v)
                     val = layer.values.add()
                     if isinstance(v, bool):
                         val.bool_value = v


### PR DESCRIPTION
In response to https://github.com/mapzen/mapbox-vector-tile/issues/28

I felt like it was slow as well and relalized I had a lot of different attribute values.

So as we need an order preserving list to store all the distinct values, I propose here to use a simple dictionnary in order to improve the `value` lookup operation.

So I put this piece of code to the test:
for 19'822 point features and just the encoding part (3 attributes on each feature)

Before:
It took 0:04:29.114788

After
It took 0:01:35.272449

This is a very minimalist approach, let me know if you think it's too simple.