### PR TITLE
Further improve attributes handling

### DIFF
--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -40,7 +40,7 @@ class VectorTile:
         self.layer.extent = self.extents
         self.keys = []
         self.values = []
-        self.seen_values = set()
+        self.seen_values_idx = {}
 
         for feature in features:
 
@@ -166,9 +166,9 @@ class VectorTile:
                     layer.keys.append(k)
                     self.keys.append(k)
                 feature.tags.append(self.keys.index(k))
-                if v not in self.seen_values:
+                if v not in self.seen_values_idx:
+                    self.seen_values_idx[v] = len(self.values)
                     self.values.append(v)
-                    self.seen_values.add(v)
                     val = layer.values.add()
                     if isinstance(v, bool):
                         val.bool_value = v
@@ -184,7 +184,7 @@ class VectorTile:
                         val.int_value = v
                     elif (isinstance(v, float)):
                         val.double_value = v
-                feature.tags.append(self.values.index(v))
+                feature.tags.append(self.seen_values_idx[v])
 
     def _handle_skipped_last(self, f, skipped_index, cur_x, cur_y, x_, y_):
         last_x = f.geometry[skipped_index - 2]


### PR DESCRIPTION
https://github.com/mapzen/mapbox-vector-tile/issues/28

I just found a way to further improve the handling of very diverse property values.

We just need to store some useful info in the dictionnary.

Same test than yesterday.

It took 0:00:06.146955

So we started at

It took 0:04:29.114788

went down to

It took 0:01:35.272449

and now it a matter of seconds

I think this should work and tests are happy. please make sure I don't break anything. ;)