### PR TITLE
Simplify key/val attribute handling

### DIFF
--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -213,3 +213,23 @@ class TestDifferentGeomFormats(BaseTestCase):
             expected_geometry=[[0, 0]],
             properties=properties,
             expected_properties={'test_empty': ''})
+
+    def test_encode_multiple_values_test(self):
+        geometry = 'POINT(0 0)'
+        properties1 = dict(foo='bar', baz='bar')
+        properties2 = dict(quux='morx', baz='bar')
+        name = 'foo'
+        feature1 = dict(geometry=geometry, properties=properties1)
+        feature2 = dict(geometry=geometry, properties=properties2)
+        source = [{
+            "name": name,
+            "features": [feature1, feature2]
+        }]
+        encoded = encode(source)
+        decoded = decode(encoded)
+        self.assertIn(name, decoded)
+        layer = decoded[name]
+        features = layer['features']
+        self.assertEqual(2, len(features))
+        self.assertEqual(features[0]['properties'], properties1)
+        self.assertEqual(features[1]['properties'], properties2)


### PR DESCRIPTION
Since we're iterating through keys in the dictionary, we won't have
duplicates anyway, so there's no need to check. And because that was the
only reason for maintaining that state, a counter should suffice here.

Somewhat similarly for values, we don't need to keep track of the values
now, because we have a dictionary for the lookups. And a counter will
also suffice here because only the length was used.

@zerebubuth could you review please?

@loicgasser would you be able to run that same test that you ran for https://github.com/mapzen/mapbox-vector-tile/pull/30 to see if we got even faster?