### PR TITLE
Add information about installing Shapely's dependency on GEOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ mapbox-vector-tile is compatible with Python 2.6, 2.7 and 3.5. It is listed on P
 pip install mapbox-vector-tile
 ```
 
+Note that `mapbox-vector-tile` depends on [Shapely](https://pypi.python.org/pypi/Shapely), a Python library for computational geometry which requires a library called [GEOS](https://trac.osgeo.org/geos/). Please see [Shapely's instructions](https://pypi.python.org/pypi/Shapely#installing-shapely) for information on how to install its prerequisites.
+
 Encoding
 --------
 


### PR DESCRIPTION
Added a paragraph to the "Install" section mentioning that there are further dependencies, and pointing to the Shapely docs to get information. That seems better than copying them here, which might get out of sync with the upstream docs.

Connects to #40.

@rmarianski could you review, please?