### PR TITLE
Round the result in quantize

### DIFF
--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -128,7 +128,7 @@ class VectorTile:
             yfac = self.extents / (maxy - miny)
             x = xfac * (x - minx)
             y = yfac * (y - miny)
-            return x, y
+            return round(x), round(y)
 
         return transform(shape, fn)
 


### PR DESCRIPTION
This shouldn't change the behavior because `round` is also called when enforcing the winding order. This just seemed more correct to do.

@zerebubuth could you review please?