### PR TITLE
Use future for py3 compat

### DIFF
--- a/mapbox_vector_tile/compat.py
+++ b/mapbox_vector_tile/compat.py
@@ -1,4 +1,5 @@
 import sys
+from builtins import map
 
 PY3 = sys.version_info[0] == 3
 
@@ -8,3 +9,7 @@ if PY3:
 else:
     from .Mapbox import vector_tile_pb2
     vector_tile = vector_tile_pb2
+
+
+def apply_map(fn, x):
+    return list(map(fn, x))

--- a/mapbox_vector_tile/compat.py
+++ b/mapbox_vector_tile/compat.py
@@ -1,0 +1,10 @@
+import sys
+
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    from .Mapbox import vector_tile_pb2_p3
+    vector_tile = vector_tile_pb2_p3
+else:
+    from .Mapbox import vector_tile_pb2
+    vector_tile = vector_tile_pb2

--- a/mapbox_vector_tile/decoder.py
+++ b/mapbox_vector_tile/decoder.py
@@ -1,12 +1,5 @@
-import sys
-
-PY3 = sys.version_info[0] == 3
-
-if PY3:
-    from .Mapbox import vector_tile_pb2_p3 as vector_tile
-    xrange = range
-else:
-    from .Mapbox import vector_tile_pb2 as vector_tile
+from past.builtins import xrange
+from .compat import vector_tile
 
 cmd_bits = 3
 

--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -230,14 +230,14 @@ class VectorTile:
         return [seq[pos:pos + size] for pos in xrange(0, len(seq), size)]
 
     def _can_handle_key(self, k):
-        return isinstance(k, str) or isinstance(k, unicode)
+        return isinstance(k, (str, unicode))
 
     def _can_handle_val(self, v):
-        if isinstance(v, str) or isinstance(v, unicode):
+        if isinstance(v, (str, unicode)):
             return True
         elif isinstance(v, bool):
             return True
-        elif isinstance(v, int) or isinstance(v, long):
+        elif isinstance(v, (int, long)):
             return True
         elif isinstance(v, float):
             return True
@@ -275,7 +275,7 @@ class VectorTile:
                             val.string_value = unicode(v, 'utf-8')
                     elif isinstance(v, unicode):
                         val.string_value = v
-                    elif isinstance(v, int) or isinstance(v, long):
+                    elif isinstance(v, (int, long)):
                         val.int_value = v
                     elif isinstance(v, float):
                         val.double_value = v

--- a/mapbox_vector_tile/encoder.py
+++ b/mapbox_vector_tile/encoder.py
@@ -1,6 +1,5 @@
 from math import fabs
 from numbers import Number
-from builtins import map
 from past.builtins import long
 from past.builtins import unicode
 from past.builtins import xrange
@@ -12,11 +11,8 @@ from shapely.ops import transform
 from shapely.wkb import loads as load_wkb
 from shapely.wkt import loads as load_wkt
 import decimal
-from .compat import PY3, vector_tile
+from .compat import PY3, vector_tile, apply_map
 
-
-def apply_map(fn, x):
-    return list(map(fn, x))
 
 # tiles are padded by this number of pixels for the current zoom level
 padding = 0

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -3,12 +3,10 @@
 Tests for vector_tile/decoder.py
 """
 
-import sys
 import unittest
 
 import mapbox_vector_tile
-
-PY3 = sys.version_info[0] == 3
+from mapbox_vector_tile.compat import PY3
 
 
 class BaseTestCase(unittest.TestCase):

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -173,6 +173,16 @@ class TestDifferentGeomFormats(BaseTestCase):
             ],
             expected_len=1)
 
+    def test_encode_multipolygon_normal_winding_order_zero_area(self):
+        geometry = 'MULTIPOLYGON (((40 40, 40 20, 40 45, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20)))'  # noqa
+        self.assertRoundTrip(
+            input_geometry=geometry,
+            expected_geometry=[
+                [[20, 35], [45, 20], [30, 5], [10, 10], [10, 30], [20, 35]],
+                [[30, 20], [20, 25], [20, 15], [30, 20]],
+            ],
+            expected_len=1)
+
     def test_encode_multipolygon_reverse_winding_order(self):
         geometry = 'MULTIPOLYGON (((10 10, 10 0, 0 0, 0 10, 10 10), (8 8, 2 8, 2 0, 8 0, 8 8)))'  # noqa
         self.assertRoundTrip(

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -2,16 +2,14 @@
 """
 Tests for vector_tile/encoder.py
 """
-import sys
 import unittest
 
 import mapbox_vector_tile
 from mapbox_vector_tile import encode, decode
+from mapbox_vector_tile.compat import PY3
 from past.builtins import long, unicode
 
 from shapely import wkt
-
-PY3 = sys.version_info[0] == 3
 
 
 class BaseTestCase(unittest.TestCase):


### PR DESCRIPTION
No functional change

This is a simple refactoring so that 

we centralize python 3 compatibility functions
we use the `future` module when we can (doc: http://python-future.org/)

I also added a test for 0 area polygons as it was missing